### PR TITLE
Fix extrapolation technique

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -11,6 +11,7 @@ mutable struct L2PenaltySolver{
   x::V
   xn::V
   y::V
+  cn::V
   dual_res::V
   s::V
   s0::V
@@ -26,6 +27,7 @@ function L2PenaltySolver(nlp::AbstractNLPModel{T,V}) where {T,V}
   x, xn, s, s0 = similar(x0), similar(x0), similar(x0), zero(x0)
   temp_b = similar(x0, nlp.meta.ncon)
   dual_res = similar(x0)
+  cn = similar(x0, nlp.meta.ncon)
   y = similar(x0, nlp.meta.ncon)
   ∇fk = similar(x0)
 
@@ -40,6 +42,7 @@ function L2PenaltySolver(nlp::AbstractNLPModel{T,V}) where {T,V}
     x,
     xn,
     y,
+    cn,
     dual_res,
     s,
     s0,

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -9,6 +9,7 @@ mutable struct L2PenaltySolver{
   PB<:AbstractRegularizedNLPModel,
 } <: AbstractOptimizationSolver
   x::V
+  xn::V
   y::V
   dual_res::V
   s::V
@@ -22,7 +23,7 @@ end
 
 function L2PenaltySolver(nlp::AbstractNLPModel{T,V}) where {T,V}
   x0 = nlp.meta.x0
-  x, s, s0 = similar(x0), similar(x0), zero(x0)
+  x, xn, s, s0 = similar(x0), similar(x0), similar(x0), zero(x0)
   temp_b = similar(x0, nlp.meta.ncon)
   dual_res = similar(x0)
   y = similar(x0, nlp.meta.ncon)
@@ -37,6 +38,7 @@ function L2PenaltySolver(nlp::AbstractNLPModel{T,V}) where {T,V}
 
   return L2PenaltySolver(
     x,
+    xn,
     y,
     dual_res,
     s,

--- a/src/extrapolate.jl
+++ b/src/extrapolate.jl
@@ -66,8 +66,8 @@ function extrapolate!(
   # Step acceptance
 
   ## Check constraints
-  cn = cons(nlp, xn) # TODO: remove rundancy when we call shift afterwards
-  norm_cn = norm(cn)
+  cons!(nlp, xn, solver.cn) # TODO: remove rundancy when we call shift afterwards
+  norm_cn = norm(solver.cn)
   if norm_cn < norm_c
     x .= xn
     return true

--- a/src/extrapolate.jl
+++ b/src/extrapolate.jl
@@ -19,8 +19,10 @@ function extrapolate!(
 
   c, norm_c = ψ.b, norm(ψ.b)
 
-  # Implicitely update the Hessian of the subproblem
+  # println(Matrix(φ.data.H))
   y = solver.y .= (τ₁/norm_c) .* c
+  hess_coord!(nlp, solver.x, y, φ.data.H.vals)
+  #println(Matrix(φ.data.H))
 
   # Prepare the linear solver
   linear_solver = solver.subsolver.subsolver.workspace
@@ -61,8 +63,23 @@ function extrapolate!(
   dx_dτ = @view x1[1:n]
 
   @views dx_dτ .-= x2[1:n] .* (dot(x1[1:n], u1[1:n])/(1 + dot(x2[1:n], u1[1:n])))
+  xn = solver.xn .= solver.x .+ dx_dτ .* (τ₂ - τ₁)
+  # Step acceptance
+
+  ## Check constraints
+  #cn = cons(nlp, xn)
+  #norm_cn = norm(cn)
+  #if norm_cn < norm_c
+  #  gn = grad(nlp, xn)
+  #  yn = τ₂ * cn / norm_cn
+  #  Jn = jac(nlp, xn)
+#
+  #  println(φ.data.c + (τ₂/τ₁) * ψ.A' * y)
+  #  println(gn + Jn' * yn)
+  #end
+#
   if (τ₂ - τ₁) * norm(dx_dτ)/norm(x) < 1
-    x .= solver.x .+ dx_dτ .* (τ₂ - τ₁)
+    x .= xn
     return true
   else
     return false

--- a/src/extrapolate.jl
+++ b/src/extrapolate.jl
@@ -19,10 +19,8 @@ function extrapolate!(
 
   c, norm_c = ψ.b, norm(ψ.b)
 
-  # println(Matrix(φ.data.H))
+  # Update multipliers
   y = solver.y .= (τ₁/norm_c) .* c
-  #hess_coord!(nlp, solver.x, y, φ.data.H.vals)
-  #println(Matrix(φ.data.H))
 
   # Prepare the linear solver
   linear_solver = solver.subsolver.subsolver.workspace

--- a/src/extrapolate.jl
+++ b/src/extrapolate.jl
@@ -21,7 +21,7 @@ function extrapolate!(
 
   # println(Matrix(φ.data.H))
   y = solver.y .= (τ₁/norm_c) .* c
-  hess_coord!(nlp, solver.x, y, φ.data.H.vals)
+  #hess_coord!(nlp, solver.x, y, φ.data.H.vals)
   #println(Matrix(φ.data.H))
 
   # Prepare the linear solver
@@ -64,21 +64,13 @@ function extrapolate!(
 
   @views dx_dτ .-= x2[1:n] .* (dot(x1[1:n], u1[1:n])/(1 + dot(x2[1:n], u1[1:n])))
   xn = solver.xn .= solver.x .+ dx_dτ .* (τ₂ - τ₁)
+
   # Step acceptance
 
   ## Check constraints
-  #cn = cons(nlp, xn)
-  #norm_cn = norm(cn)
-  #if norm_cn < norm_c
-  #  gn = grad(nlp, xn)
-  #  yn = τ₂ * cn / norm_cn
-  #  Jn = jac(nlp, xn)
-#
-  #  println(φ.data.c + (τ₂/τ₁) * ψ.A' * y)
-  #  println(gn + Jn' * yn)
-  #end
-#
-  if (τ₂ - τ₁) * norm(dx_dτ)/norm(x) < 1
+  cn = cons(nlp, xn) # TODO: remove rundancy when we call shift afterwards
+  norm_cn = norm(cn)
+  if norm_cn < norm_c
     x .= xn
     return true
   else


### PR DESCRIPTION
Instead of basing the acceptance rule on a relative error condition over iterates, introduced in #79; we now base it on the primal feasibility.