### PR TITLE
Do not reset the nonmonotone vector on calls to ir2n but only in reset!

### DIFF
--- a/src/ir2n.jl
+++ b/src/ir2n.jl
@@ -52,7 +52,8 @@ function PenaltyR2NSolver(
   )
 end
 
-function SolverCore.reset!(solver::PenaltyR2NSolver)
+function SolverCore.reset!(solver::PenaltyR2NSolver{T}) where{T}
+  fill!(solver.m_fh_hist, T(-Inf))
   reset!(solver.subpb)
 end
 
@@ -94,7 +95,7 @@ function SolverCore.solve!(
   ∇fk = solver.subpb.model.data.c
   xkn = solver.xkn
   s, y, dual_res = solver.s, solver.y, solver.dual_res
-  m_fh_hist = solver.m_fh_hist .= T(-Inf)
+  m_fh_hist = solver.m_fh_hist
 
   m_monotone = length(m_fh_hist) + 1
 


### PR DESCRIPTION
It seems that resetting it at each call makes our solver less robust.
A minimal example is with the problem 

```
nlp = CUTEstModel("EXTROSNBNE")
  Problem name: EXTROSNBNE
   All variables: ████████████████████ 1000   All constraints: ████████████████████ 999   
            free: ████████████████████ 1000              free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
         low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                fixed: ████████████████████ 999   
          infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
            nnzh: ( 99.80% sparsity)   999             linear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
                                                    nonlinear: ████████████████████ 999   
                                                         nnzj: ( 99.80% sparsity)   1998  
                                                     lin_nnzj: (------% sparsity)         
                                                     nln_nnzj: ( 99.80% sparsity)   1998  
```
with this modification, we get a first order minimizer in a few iterations:
```
julia> L2Penalty(nlp, atol = 1e-6, rtol = 0.0, verbose = 1)
[ Info:  outer  inner     f(x)  pr_feas      pεₖ  du_feas      dεₖ        τ      ‖x‖ 
[ Info:      0      0 -2.0e+00  2.0e+01  1.0e+00  1.4e-17  2.0e-02  1.0e+00  3.2e+01
[ Info:      1     11 -2.0e+00  6.9e+00  1.0e+00  7.1e-03  1.0e-06  2.0e+00  2.7e+00
[ Info:      2      5 -2.0e+00  3.2e-01  1.0e+00  2.4e-03  1.0e-06  3.0e+00  3.0e+00
[ Info:      3      1 -2.0e+00  9.7e-02  1.0e+00  7.0e-04  1.0e-06  4.0e+00  3.1e+00
[ Info:      4      6 -2.0e+00  1.1e-02  1.0e+00  8.8e-05  1.0e-06  5.0e+00  3.6e+00
[ Info:      5      7 -2.0e+00  1.2e-03  1.0e+00  1.1e-05  1.0e-06  6.0e+00  3.9e+00
[ Info:      6      8 -2.0e+00  1.1e-03  1.0e+00  3.8e-06  1.0e-06  7.0e+00  4.3e+00
[ Info:      7     11 -2.0e+00  8.3e-04  1.0e+00  6.4e-07  1.0e-06  8.0e+00  4.8e+00
[ Info:      8      1 -2.0e+00  3.9e-05  1.0e+00  4.8e-08  1.0e-06  9.0e+00  4.8e+00
[ Info:      9     10 -2.0e+00  8.0e-06  1.0e+00  9.3e-09  1.0e-06  1.0e+01  5.0e+00
[ Info:     10     10 -2.0e+00  2.6e-06  1.0e+00  3.0e-09  1.0e-06  1.1e+01  5.2e+00
[ Info:     11      9 -2.0e+00  2.5e-06  1.0e+00  6.1e-09  1.0e-06  1.2e+01  5.3e+00
[ Info:     12      1 -2.0e+00  1.1e-06  1.0e+00  1.3e-09  1.0e-06  1.3e+01  5.3e+00
[ Info:     13      9 -2.0e+00  5.5e-07  1.0e+00  2.1e-09  1.0e-06  1.4e+01  5.4e+00
"Execution stats: first-order stationary"
```
while it fails without the modification. Note that this problem is hard to solve; IPOPT fails.