### PR TITLE
Benchmarks: display number of factorization comparison instead of CPU time

### DIFF
--- a/.github/workflows/CompareBenchmarks.yml
+++ b/.github/workflows/CompareBenchmarks.yml
@@ -22,7 +22,18 @@ jobs:
       - name: Use Julia cache
         uses: julia-actions/cache@v2
 
-      - name: Download latest RunBenchmark artifact on this branch
+      - name: Download benchmark artifact (workflow_run)
+        if: github.event_name == 'workflow_run'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh run download "${{ github.event.workflow_run.id }}" \
+            --name cutest-benchmark-stats \
+            --dir artifacts/current
+
+      - name: Download benchmark artifact (manual/workflow_call)
+        if: github.event_name != 'workflow_run'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.ref_name }}

--- a/benchmark/compare-benchmarks.jl
+++ b/benchmark/compare-benchmarks.jl
@@ -107,7 +107,7 @@ load_stats(reference_dir, stats, "_reference")
 p = plot(
   pairwise_plot(stats, [:l2penalty_exact_reference, :l2penalty_exact_current]),
   pairwise_plot(stats, [:l2penalty_lbfgs_reference, :l2penalty_lbfgs_current]),
-  layout = (3, 1),
+  layout = (2, 1),
   size = (1920, 1080),
 )
 

--- a/benchmark/compare-benchmarks.jl
+++ b/benchmark/compare-benchmarks.jl
@@ -27,7 +27,7 @@ function load_stats(dir::AbstractString, stats, suffix = "")
   return stats
 end
 
-function pairwise_plot(stats, keys)
+function pairwise_plot(stats, keys; compare_n_fact = false)
   solved(df) = (df.status .== :first_order) # TODO: add infeasible problems
   costs = [
     df -> .!solved(df) * Inf + df.elapsed_time,
@@ -35,6 +35,11 @@ function pairwise_plot(stats, keys)
     df -> .!solved(df) * Inf + df.neval_grad,
   ]
   costnames = ["CPU Time", "# Objective Evals", "# Gradient Evals"]
+
+  if compare_n_fact && hasproperty(stats, :n_fact)
+    costnames[1] ="# Factorizations"
+    costs[1] = df -> .!solved(df) * Inf + df.n_fact
+  end
 
   stats_subset = filter(kv -> kv[1] in keys, stats)
 
@@ -105,8 +110,8 @@ load_stats(current_dir, stats, "_current")
 load_stats(reference_dir, stats, "_reference")
 
 p = plot(
-  pairwise_plot(stats, [:l2penalty_exact_reference, :l2penalty_exact_current]),
-  pairwise_plot(stats, [:l2penalty_lbfgs_reference, :l2penalty_lbfgs_current]),
+  pairwise_plot(stats, [:l2penalty_exact_reference, :l2penalty_exact_current], compare_n_fact = true),
+  pairwise_plot(stats, [:l2penalty_lbfgs_reference, :l2penalty_lbfgs_current], compare_n_fact = true),
   layout = (2, 1),
   size = (1920, 1080),
 )

--- a/src/ExactPenaltyExecutionStats.jl
+++ b/src/ExactPenaltyExecutionStats.jl
@@ -1,7 +1,7 @@
 export ExactPenaltyExecutionStats
 
 function ExactPenaltyExecutionStats(nlp::AbstractNLPModel{T,V}) where {T,V}
-  stats = GenericExecutionStats(nlp, solver_specific = Dict{Symbol,T}())
-  set_solver_specific!(stats, :theta, T(Inf))
+  stats = GenericExecutionStats(nlp, solver_specific = Dict{Symbol,Int}())
+  set_solver_specific!(stats, :n_fact, T(0))
   return stats
 end

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -407,6 +407,7 @@ function SolverCore.solve!(
     set_objective!(stats, fx)
     set_residuals!(stats, primal_feas, dual_feas)
     set_constraint_multipliers!(stats, solver.y)
+    set_solver_specific!(stats, :n_fact, solver.substats.solver_specific[:n_fact])
 
     set_status!(
       stats,

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -37,6 +37,7 @@ function L2PenaltySolver(nlp::AbstractNLPModel{T,V}) where {T,V}
 
   set_solver_specific!(substats, :primal_ktol, T(0))
   set_solver_specific!(substats, :dual_ktol, T(0))
+  set_solver_specific!(substats, :n_fact, T(0))
 
   return L2PenaltySolver(
     x,

--- a/src/ir2n.jl
+++ b/src/ir2n.jl
@@ -54,6 +54,7 @@ end
 
 function SolverCore.reset!(solver::PenaltyR2NSolver{T}) where {T}
   fill!(solver.m_fh_hist, T(-Inf))
+  reset!(solver.subsolver)
   reset!(solver.subpb)
 end
 
@@ -236,6 +237,7 @@ function SolverCore.solve!(
     set_solver_specific!(stats, :smooth_obj, fk)
     set_solver_specific!(stats, :nonsmooth_obj, hk)
     set_solver_specific!(stats, :sigma, σk)
+    set_solver_specific!(stats, :n_fact, get_n_fact(solver.subsolver.workspace))
     set_iter!(stats, stats.iter + 1)
     set_time!(stats, time() - start_time)
 

--- a/src/linear_algebra/construct_workspace.jl
+++ b/src/linear_algebra/construct_workspace.jl
@@ -1,7 +1,22 @@
+abstract type PenaltyWorkspace end
+abstract type PenaltyDirectWorkspace    <: PenaltyWorkspace end
+abstract type PenaltyIterativeWorkspace <: PenaltyWorkspace end
+
 function construct_workspace(H::M, u1::V, n::Int, m::Int; solver = :minres_qlp) where {M,V}
   if solver == :minres_qlp
     return construct_minres_qlp_workspace(H, u1, n, m)
   elseif solver == :ldlt
     return construct_ldlt_workspace(H, u1, n, m)
   end
+end
+
+get_n_fact(workspace::PenaltyIterativeWorkspace) = 0
+get_n_fact(workspace::PenaltyDirectWorkspace) = workspace._n_fact
+
+function set_n_fact!(workspace::PenaltyIterativeWorkspace, n::Int)
+  return
+end
+
+function set_n_fact!(workspace::PenaltyDirectWorkspace, n::Int)
+  workspace._n_fact = n
 end

--- a/src/linear_algebra/krylov.jl
+++ b/src/linear_algebra/krylov.jl
@@ -1,4 +1,4 @@
-struct PenaltyKrylovWorkspace{WP<:KrylovWorkspace,OP<:OpK2}
+struct PenaltyKrylovWorkspace{WP<:KrylovWorkspace,OP<:OpK2} <: PenaltyIterativeWorkspace
   M::WP
   H::OP
   n::Int

--- a/src/linear_algebra/ldlt.jl
+++ b/src/linear_algebra/ldlt.jl
@@ -3,7 +3,7 @@ mutable struct PenaltyLDLTWorkspace{
   K2<:AbstractMatrix,
   V<:AbstractVector,
   T<:Real,
-}
+} <: PenaltyDirectWorkspace
   M::WP
   H::K2
   x::V
@@ -13,6 +13,7 @@ mutable struct PenaltyLDLTWorkspace{
   n::Int
   m::Int
   status::Symbol
+  _n_fact::Int
 end
 
 function get_H(
@@ -42,6 +43,7 @@ function construct_ldlt_workspace(
     n,
     m,
     :uninitialized,
+    0
   )
 end
 
@@ -62,6 +64,7 @@ function construct_ldlt_workspace(
     n,
     m,
     :uninitialized,
+    0
   )
 end
 
@@ -210,7 +213,10 @@ function solve_system!(
 ) where {V<:AbstractVector,WP,K2}
   workspace.status = :success
 
-  factorized(workspace.M) || ldl_factorize!(workspace.H, workspace.M)
+  if !factorized(workspace.M) 
+    ldl_factorize!(workspace.H, workspace.M)
+    workspace._n_fact += 1
+  end
   if !factorized(workspace.M)
     workspace.status = :failed
     return
@@ -254,7 +260,10 @@ function solve_system!(
   # Step 1: Factorize
   # [σI+ξI  Aᵀ]
   # [A     -αI]
-  factorized(workspace.M) || ldl_factorize!(workspace.H.H, workspace.M)
+  if !factorized(workspace.M) 
+    ldl_factorize!(workspace.H.H, workspace.M)
+    workspace._n_fact += 1
+  end
   if !factorized(workspace.M)
     workspace.status = :failed
     return

--- a/src/subsolvers/more-sorensen.jl
+++ b/src/subsolvers/more-sorensen.jl
@@ -239,3 +239,7 @@ function get_primal_dual_sol!(s, y, solver::MoreSorensenSolver)
   s .= @view solver.x1[1:n]
   y .= @view solver.x1[(n+1):end]
 end
+
+function SolverCore.reset!(solver::MoreSorensenSolver{T}) where {T}
+  set_n_fact!(solver.workspace, 0)
+end

--- a/test/test-cutest.jl
+++ b/test/test-cutest.jl
@@ -57,6 +57,7 @@ function test_problem(name, primal_solution, dual_solution, expected_status)
       ) ≤ 100*tol
     end
     @test stats.primal_feas == norm(cons(nlp, stats.solution), Inf)
+    @test stats.solver_specific[:n_fact] > 0
 
     # Test stability and allocations
     NLPModels.reset!(LBFGS_model)
@@ -72,6 +73,7 @@ function test_problem(name, primal_solution, dual_solution, expected_status)
     @test all(stats_optimized.multipliers .== stats.multipliers)
     @test all(stats_optimized.solution .== stats.solution)
     @test stats_optimized.iter == stats.iter
+    @test stats_optimized.solver_specific[:n_fact] == stats.solver_specific[:n_fact]
   end
 
   @testset "Exact" begin
@@ -90,6 +92,7 @@ function test_problem(name, primal_solution, dual_solution, expected_status)
       ) ≤ 100*tol
     end
     @test stats.primal_feas == norm(cons(nlp, stats.solution), Inf)
+    @test stats.solver_specific[:n_fact] > 0
 
     # Test stability and allocations
     solver = L2PenaltySolver(nlp)
@@ -105,6 +108,7 @@ function test_problem(name, primal_solution, dual_solution, expected_status)
     @test all(stats_optimized.multipliers .== stats.multipliers)
     @test all(stats_optimized.solution .== stats.solution)
     @test stats_optimized.iter == stats.iter
+    @test stats_optimized.solver_specific[:n_fact] == stats.solver_specific[:n_fact]
   end
 
   finalize(nlp)


### PR DESCRIPTION
I have no idea how to do this for IPOPT though. 
Maybe with a callback but i can not see how i'd see when the solver makes inertia corrections.

No conflict with #111.