### PR TITLE
Increase default memory size in CompactBFGS function

### DIFF
--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -138,6 +138,6 @@ finalize(nlp) # hide
 !!! tip "L-BFGS options"
     The `CompactBFGSModel` constructor supports keyword arguments to customize your approximation.
     Those are
-    * `mem::Int = 5`: memory parameter for the limited-memory approximation.
+    * `mem::Int = 6`: memory parameter for the limited-memory approximation.
     * `scaling::Bool = true`: whether we scale $B_0 = \gamma I$ with $\gamma = y^Ty / s^T y$, where $s$ is the step and $y$ is the difference of the two last gradients of the Lagrangian.
     * `max_skip::Int = 2` (*advanced*): if we skipped a pair $(s, y)$ more than `max_skip` times in a row, we reset the approximation. 

--- a/src/types/quasi-newton/CompactBFGS.jl
+++ b/src/types/quasi-newton/CompactBFGS.jl
@@ -22,7 +22,7 @@ end
 function CompactBFGS(
   T::Type,
   n::I;
-  mem::I = 5,
+  mem::I = 6,
   scaling::Bool = true,
   damped::Bool = false,
   σ₂::Float64 = 0.99,

--- a/test/test-quasi-newton.jl
+++ b/test/test-quasi-newton.jl
@@ -3,7 +3,7 @@
 
   # Test pushing without scaling
   n = nlp.meta.nvar
-  compact_bfgs_nlp = CompactBFGSModel(nlp, scaling = false, max_skip = typemax(Int))
+  compact_bfgs_nlp = CompactBFGSModel(nlp, mem = 5, scaling = false, max_skip = typemax(Int))
   bfgs_op_nlp = LBFGSModel(nlp, scaling = false)
 
   for _ = 1:100
@@ -26,7 +26,7 @@
   nallocs = @allocated push!(compact_bfgs_nlp, s, y)
   @test nallocs == 0
 
-  compact_bfgs_nlp = CompactBFGSModel(nlp, max_skip = typemax(Int))
+  compact_bfgs_nlp = CompactBFGSModel(nlp, mem = 5, max_skip = typemax(Int))
   bfgs_op_nlp = LBFGSModel(nlp)
 
   for _ = 1:100


### PR DESCRIPTION
Match IPOPT default value