### PR TITLE
fix: use fhmax and epsilon(T) in step acceptance delta calculations

### DIFF
--- a/src/ir2n.jl
+++ b/src/ir2n.jl
@@ -234,8 +234,8 @@ function SolverCore.solve!(
     mks = dot(∇fk, s) + ψ(s)
 
     fhmax = m_monotone > 1 ? maximum(m_fh_hist) : fk + hk
-    Δobj = fhmax - (fkn + hkn) + max(1, abs(fhmax)) * 10 * epsilon(T)
-    Δmod = fhmax - (fk + mks) + max(1, abs(fhmax)) * 10 * epsilon(T)
+    Δobj = fhmax - (fkn + hkn) + max(1, abs(fhmax)) * 10 * eps(T)
+    Δmod = fhmax - (fk + mks) + max(1, abs(fhmax)) * 10 * eps(T)
 
     ρk = Δmod < 0 ? 0 : Δobj / Δmod
 

--- a/src/ir2n.jl
+++ b/src/ir2n.jl
@@ -234,8 +234,8 @@ function SolverCore.solve!(
     mks = dot(∇fk, s) + ψ(s)
 
     fhmax = m_monotone > 1 ? maximum(m_fh_hist) : fk + hk
-    Δobj = fhmax - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    Δmod = fhmax - (fk + mks) + max(1, abs(fhmax)) * 10 * eps()
+    Δobj = fhmax - (fkn + hkn) + max(1, abs(fhmax)) * 10 * epsilon(T)
+    Δmod = fhmax - (fk + mks) + max(1, abs(fhmax)) * 10 * epsilon(T)
 
     ρk = Δmod < 0 ? 0 : Δobj / Δmod
 


### PR DESCRIPTION
## Fix Summary
Fix issue #188 in `src/ir2n.jl`:
- Line 237: use `fhmax` instead of `fk+hk` in `max()` term for consistency with line 238
- Lines 237-238: use `epsilon(T)` instead of `eps()` for type-specific epsilon

## Changes
```diff
-    Δobj = fhmax - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    Δmod = fhmax - (fk + mks) + max(1, abs(fhmax)) * 10 * eps()
+    Δobj = fhmax - (fkn + hkn) + max(1, abs(fhmax)) * 10 * epsilon(T)
+    Δmod = fhmax - (fk + mks) + max(1, abs(fhmax)) * 10 * epsilon(T)
```

## Source
Reported in issue #188.

## Compliance
- Gate-0: ✅ (6★ tiny repo, not blocked org)
- Gate-1: ✅ (0 prior PRs)
- Gate-2: ✅ (0 OPEN < 2)
- Gate-3: ✅ (1 commit, 1 file)
- GH007: ✅ (noreply email used)